### PR TITLE
Make the ruby version 2.0 or above not 2.0 only

### DIFF
--- a/openfoodfacts.gemspec
+++ b/openfoodfacts.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '~> 2.0' # Needed for keyword arguments
+  spec.required_ruby_version = '>= 2.0' # Needed for keyword arguments
   
   spec.add_runtime_dependency 'hashie', '~> 3.3'
 


### PR DESCRIPTION
This allow people with ruby 2.1 to install the open food facts gem